### PR TITLE
Add cleanup

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -40,11 +40,7 @@ func (f factory) Create(config *Config, logger log.Logger) (deployer.Connector, 
 	if err != nil {
 		return &Connector{}, fmt.Errorf("podman binary check failed with error: %w", err)
 	}
-	connectionName := ""
-	if config.Podman.ConnectionName != nil {
-		connectionName = *config.Podman.ConnectionName
-	}
-	podman := cliwrapper.NewCliWrapper(podmanPath, logger, connectionName)
+	podman := cliwrapper.NewCliWrapper(podmanPath, logger, config.Podman.ConnectionName)
 
 	var rngSeed int64
 	if config.Podman.RngSeed == 0 {

--- a/internal/cliwrapper/cliwrapper.go
+++ b/internal/cliwrapper/cliwrapper.go
@@ -18,11 +18,11 @@ type cliWrapper struct {
 	connectionName []string
 }
 
-func NewCliWrapper(fullPath string, logger log.Logger, connectionName string) CliWrapper {
+func NewCliWrapper(fullPath string, logger log.Logger, connectionName *string) CliWrapper {
 	// Specify podman --connection string if provided
 	connection := []string{}
-	if connectionName != "" {
-		connection = []string{"--connection=" + connectionName}
+	if connectionName != nil {
+		connection = append(connection, "--connection="+*connectionName)
 	}
 
 	return &cliWrapper{

--- a/internal/cliwrapper/cliwrapper_test.go
+++ b/internal/cliwrapper/cliwrapper_test.go
@@ -12,7 +12,7 @@ import (
 	"go.flow.arcalot.io/podmandeployer/tests"
 )
 
-func Podman_ImageExists(t *testing.T, connectionName string) {
+func podmanImageExists(t *testing.T, connectionName *string) {
 	logger := log.NewTestLogger(t)
 	tests.RemoveImage(logger, tests.TestImage)
 
@@ -20,7 +20,7 @@ func Podman_ImageExists(t *testing.T, connectionName string) {
 
 	assert.NotNil(t, tests.GetPodmanPath())
 
-	cmd := exec.Command(tests.GetPodmanPath(), "pull", tests.TestImage) //nolint:gosec
+	cmd := exec.Command(tests.GetPodmanPath(), "pull", tests.TestImage) //nolint:gosec  // Command line is trusted
 	if err := cmd.Run(); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -50,58 +50,71 @@ func Podman_ImageExists(t *testing.T, connectionName string) {
 }
 
 func TestPodman_ImageExists(t *testing.T) {
-	Podman_ImageExists(t, "")
+	podmanImageExists(t, nil)
 }
 
 func TestPodman_Remote_ImageExists(t *testing.T) {
-	var tmpPodmanSocketCmd *exec.Cmd
-
-	// Check if there is an existing connection of `podman-machine-default` since this is included when installing
-	// podman desktop for macOS.
+	// Check if there is an existing connection of `podman-machine-default`
+	// since this is included when installing podman desktop for macOS.
 	connectionName := "podman-machine-default"
-	chkDefaultConnectionCmd := exec.Command(tests.GetPodmanPath(), "--connection", connectionName, "system", "info") //nolint:gosec
-	if err := chkDefaultConnectionCmd.Run(); err == nil {
-		Podman_ImageExists(t, connectionName)
-	} else if runtime.GOOS == "linux" {
-		// The podman-machine-default doesn't exist then for Linux, create a temporary socket
-
-		// Setup
-		connectionName = "arcaflow-engine-deployer-podman-test"
-		podmanSocketPath := "unix:///var/tmp/" + connectionName + ".sock"
-
-		tmpPodmanSocketCmd = exec.Command(tests.GetPodmanPath(), "system", "service", "--time=0", podmanSocketPath)
-		if err := tmpPodmanSocketCmd.Start(); err != nil {
-			t.Fatalf("Failed to create temporary podman socket")
+	chkDefaultConnectionCmd := exec.Command(tests.GetPodmanPath(), "--connection", connectionName, "system", "info") //nolint:gosec  // Command line is trusted
+	if err := chkDefaultConnectionCmd.Run(); err != nil {
+		// The podman-machine-default connection doesn't exist, so try to create
+		// an alternative connection service.  For now, only try this on Linux.
+		//
+		//goland:noinspection GoBoolExpressions  // The linter cannot tell that this expression is not constant.
+		if runtime.GOOS != "linux" {
+			t.Skipf("There is no default Podman connection and no support for creating it on %s.", runtime.GOOS)
 		}
 
-		addConnectionCmd := exec.Command(tests.GetPodmanPath(), "system", "connection", "add", connectionName, podmanSocketPath)
-		if err := addConnectionCmd.Run(); err != nil {
-			t.Fatalf("Failed to add connection: " + connectionName)
-		}
-
-		// Run test
-		Podman_ImageExists(t, connectionName)
-
-		// Clean up
-		if err := tmpPodmanSocketCmd.Process.Kill(); err != nil {
-			t.Fatalf("Failed to kill temporary socket")
-		}
-
-		delConnectionCmd := exec.Command(tests.GetPodmanPath(), "system", "connection", "remove", connectionName)
-		if err := delConnectionCmd.Run(); err != nil {
-			t.Fatalf("Failed to delete connection: " + connectionName)
-		}
-		// Unexpected setup, force user to add podman-machine-default
-	} else {
-		t.Fatalf("Unsupported configuration")
+		connectionName = createPodmanConnection(t)
 	}
+
+	// Run the test
+	podmanImageExists(t, &connectionName)
+}
+
+// createPodmanConnection creates a Podman API service process and configures
+// a Podman "connection" to allow it to be used for remote Podman invocations.
+func createPodmanConnection(t *testing.T) (connectionName string) {
+	// Setup
+	t.Logf("Adding a local Podman API service and connection.")
+	connectionName = "arcaflow-engine-deployer-podman-test"
+	podmanSocketPath := "unix:///var/tmp/" + connectionName + ".sock"
+
+	podmanApiServiceCmd := exec.Command(tests.GetPodmanPath(), "system", "service", "--time=0", podmanSocketPath) //nolint:gosec  // Command line is trusted
+	if err := podmanApiServiceCmd.Start(); err != nil {
+		t.Fatal("Failed to create temporary Podman API service process")
+	}
+
+	t.Cleanup(func() {
+		t.Logf("Killing the Podman API service process.")
+		if err := podmanApiServiceCmd.Process.Kill(); err != nil {
+			t.Fatal("Failed to kill Podman API service process.")
+		}
+	})
+
+	addConnectionCmd := exec.Command(tests.GetPodmanPath(), "system", "connection", "add", connectionName, podmanSocketPath) //nolint:gosec  // Command line is trusted
+	if err := addConnectionCmd.Run(); err != nil {
+		t.Fatalf("Failed to add connection %q.", connectionName)
+	}
+
+	t.Cleanup(func() {
+		t.Logf("Removing the Podman connection.")
+		delConnectionCmd := exec.Command(tests.GetPodmanPath(), "system", "connection", "remove", connectionName) //nolint:gosec  // Command line is trusted
+		if err := delConnectionCmd.Run(); err != nil {
+			t.Fatalf("Failed to delete connection %q.", connectionName)
+		}
+	})
+
+	return connectionName
 }
 
 func TestPodman_PullImage(t *testing.T) {
 	logger := log.NewTestLogger(t)
 	tests.RemoveImage(logger, tests.TestImageMultiPlatform)
 
-	podman := NewCliWrapper(tests.GetPodmanPath(), logger, "")
+	podman := NewCliWrapper(tests.GetPodmanPath(), logger, nil)
 	assert.NotNil(t, tests.GetPodmanPath())
 
 	// pull without platform


### PR DESCRIPTION
Hi Ed, here's another PR with some updates for your PR https://github.com/arcalot/arcaflow-engine-deployer-podman/pull/61.  The big deal is reworking the cleanup in your test to make it more robust, but, while I was at it, I folded in the items from my feedback to your latest changes.  Here's what I've got for you:
- Moved the code which kills the Podman service process and removes the Podman connection into cleanup functions called by `t.Cleanup()`, so that, if the test crashes or otherwise misbehaves, the cleanup will still be done.
- Using the cleanup handlers allows the code to use a common call to the test helper function regardless of whether it opts to create a local service or whether it uses the default one, which makes the code a little more graceful.
- Moved the code to create the local service into a helper function to appease the linter.  Also, added lint directives to the `exec.Command()` calls and added some annotations to them.
- Changed `NewCliWrapper()` to take a pointer to the connection string instead of the value:  this allows the caller to pass the configuration value straight through without having to conditionally instantiate an otherwise useless empty string.
- Tweaked `NewCliWrapper()` to use `append()` to add the connection option instead of instantiating a new slice.
- Renamed a few things in the test code.
- Changed the image-exists helper test function to take the connection as a pointer instead of a string, so that it can pass the value straight through to `NewCliWrapper()` and fixed the callers.

So, it now passes the linters and the tests.

Thanks for your help with this!